### PR TITLE
docker won't docker: bump ant

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get -y install wget
 
 RUN mkdir /java && mkdir /ant \
  && { wget -q -O - https://download.bell-sw.com/java/11.0.26+9/bellsoft-jdk11.0.26+9-linux-amd64-full.tar.gz | tar -xzf - -C /java --strip-component=1 ; } \
- && { wget -q -O - https://dlcdn.apache.org//ant/binaries/apache-ant-1.10.15-bin.tar.gz | tar -xzf - -C /ant --strip-component=1 ; }
+ && { wget -q -O - https://dlcdn.apache.org//ant/binaries/apache-ant-1.10.17-bin.tar.gz | tar -xzf - -C /ant --strip-component=1 ; }
 
 FROM prepare AS build
 


### PR DESCRIPTION
Looks like the referenced version of Ant was pulled from Apache's CDN.

```
$ docker build --no-cache -t md:build -f docker/Dockerfile docker/

[+] Building 16.8s (6/7)                                                                                                                                        docker:orbstack
 => [internal] load build definition from Dockerfile                                                                                                                       0.0s
 => => transferring dockerfile: 597B                                                                                                                                       0.0s
 => [internal] load metadata for docker.io/library/debian:bookworm-slim                                                                                                    0.6s
 => [internal] load .dockerignore                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                            0.0s
 => CACHED [prepare 1/3] FROM docker.io/library/debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252                               0.0s
 => => resolve docker.io/library/debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252                                              0.0s
 => [prepare 2/3] RUN apt-get update && apt-get -y install wget                                                                                                            2.7s
 => ERROR [prepare 3/3] RUN mkdir /java && mkdir /ant  && { wget -q -O - https://download.bell-sw.com/java/11.0.26+9/bellsoft-jdk11.0.26+9-linux-amd64-full.tar.gz | tar  13.3s
------
 > [prepare 3/3] RUN mkdir /java && mkdir /ant  && { wget -q -O - https://download.bell-sw.com/java/11.0.26+9/bellsoft-jdk11.0.26+9-linux-amd64-full.tar.gz | tar -xzf - -C /java --strip-component=1 ; }  && { wget -q -O - https://dlcdn.apache.org//ant/binaries/apache-ant-1.10.15-bin.tar.gz | tar -xzf - -C /ant --strip-component=1 ; }:
11.16
11.16 gzip: stdin: unexpected end of file
11.16 tar: Child returned status 1
11.16 tar: Error is not recoverable: exiting now
------
Dockerfile:5
--------------------
   4 |
   5 | >>> RUN mkdir /java && mkdir /ant \
   6 | >>>  && { wget -q -O - https://download.bell-sw.com/java/11.0.26+9/bellsoft-jdk11.0.26+9-linux-amd64-full.tar.gz | tar -xzf - -C /java --strip-component=1 ; } \
   7 | >>>  && { wget -q -O - https://dlcdn.apache.org//ant/binaries/apache-ant-1.10.15-bin.tar.gz | tar -xzf - -C /ant --strip-component=1 ; }
   8 |
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c mkdir /java && mkdir /ant  && { wget -q -O - https://download.bell-sw.com/java/11.0.26+9/bellsoft-jdk11.0.26+9-linux-amd64-full.tar.gz | tar -xzf - -C /java --strip-component=1 ; }  && { wget -q -O - https://dlcdn.apache.org//ant/binaries/apache-ant-1.10.15-bin.tar.gz | tar -xzf - -C /ant --strip-component=1 ; }" did not complete successfully: exit code: 2
```